### PR TITLE
fix: update success http code detection logic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ _require () {
 _require jq curl fzf
 
 # Get themes
-status_code=$(curl -I "https://github.com/AvinashReddy3108/Gogh4Termux" 2>&1 | awk '/HTTP\// {print $2}')
+status_code=$(curl -s -o /dev/null -I -w "%{http_code}" "https://github.com/AvinashReddy3108/Gogh4Termux")
 if [ "$status_code" -eq "200" ]; then
     echo "Fetching themes list from repository, please wait."
     theme=$(curl -fSsL https://api.github.com/repos/AvinashReddy3108/Gogh4Termux/git/trees/master | jq -r '.tree[] | select (.path | contains(".properties")) | .path' | fzf)


### PR DESCRIPTION
Hey! I've noticed an incorrect behaviour when trying to use `install.sh` script. Looks like the format of response changed and the script could not detect `200` http success code correctly. Because of that it always prints "Make sure you're connected to the internet!".

I found a problem. `curl -I "https://github.com/AvinashReddy3108/Gogh4Termux" 2>&1 | awk '/HTTP\// {print $2}'` prints `0`, instead of `200`, because of this response 
![image](https://github.com/AvinashReddy3108/Gogh4Termux/assets/33424304/0cacbdef-35fd-438f-9dca-8958a47029ee)
so `${print $2}` prints `0`.

In this PR I changed the logic of detecting `200` success http code via `curl` mechanism instead of parsing the response with `awk`.